### PR TITLE
Changes outfit to default to unlocked

### DIFF
--- a/WoLMod/WoLModPlugin.cs
+++ b/WoLMod/WoLModPlugin.cs
@@ -15,7 +15,7 @@ namespace WOLModTemplate {
             {
                 new OutfitModStat(OutfitModStat.OutfitModType.Health,100,0,0,false),
                 new OutfitModStat(OutfitModStat.OutfitModType.Speed,0,0.2f,0,false)
-            }, false, false);
+            }, true, false);
 
             Outfits.Register(outfit);
 


### PR DESCRIPTION
Thanks for this awesome guide!  I used it with my eight year old son to add a new robe that has all the perks he wants and to help him stay alive through a dangerous run!

But I noticed that the new robe had to be purchased at the store, so I then realized that the tutorial adds a the item but in a locked state.  So this super simple change just adds the robe in an unlocked state, to go along with the tutorial.